### PR TITLE
Several bugfixes

### DIFF
--- a/data/enemies/generic/tektite.lua
+++ b/data/enemies/generic/tektite.lua
@@ -118,7 +118,7 @@ function behavior:create(enemy, properties)
     math.randomseed(os.time()) -- Initialize random seed.
     local d = 2 * math.random() - 1 -- Random real number in [-1,1].
     angle = angle + d * math.pi / 2 -- Alter jumping angle, randomly. /4
-    m:set_speed(properties.jumping_speed)
+    m:set_speed(properties.jump_speed)
     m:set_angle(angle)
     m:start(self)
     -- Finish the jump.

--- a/data/enemies/stalfos_knight.lua
+++ b/data/enemies/stalfos_knight.lua
@@ -12,6 +12,15 @@ local positions = {
   {x = 360, y = 304, direction4 = 3},
   {x = 336, y = 184, direction4 = 3}
 }
+if map:get_id() == "170" then
+  -- Positions are different if this is the boss run.
+  positions = {
+    {x = 224, y = 238, direction4 = 3},
+    {x = 232, y = 142, direction4 = 3},
+    {x = 360, y = 254, direction4 = 3},
+    {x = 336, y = 134, direction4 = 3}
+  }
+end
 
 -- Stalfos: An undead soldier boss.
 

--- a/data/enemies/vire_sorceror.lua
+++ b/data/enemies/vire_sorceror.lua
@@ -14,7 +14,7 @@ local positions = {
 }
 if map:get_id() == "170" then
   -- Positions are different if this is the boss run.
-  local positions = {
+  positions = {
     {x = 440, y = 148, direction4 = 3},
     {x = 321, y = 244, direction4 = 3},
     {x = 216, y = 180, direction4 = 3},

--- a/data/entities/npc_crista.lua
+++ b/data/entities/npc_crista.lua
@@ -102,7 +102,7 @@ function entity:on_interaction()
         end
       end)
     end
-  elseif game:get_value("i1631") >= 7 and last_speak ~= 1 then
+  elseif game:get_value("i1631") >= 7 and game:get_value("i2014") >= 10 and game:get_value("i2015") >= 10 and last_speak ~= 1 then
     last_speak = 1
     game:start_dialog("crista.5.shop_progress")  -- Progress on plants fetch quest.
   elseif game:get_value("i1847") >= 25 and game:get_value("i2015") < 10 then  -- Has enough deku sticks for blue potion (and hasn't been made before).

--- a/data/items/poe_soul.lua
+++ b/data/items/poe_soul.lua
@@ -1,4 +1,5 @@
 local item = ...
+local game = item:get_game() 
 
 -- This script defines the behavior of pickable poe souls present on the map.
 
@@ -42,27 +43,20 @@ end
 
 -- Obtaining a poe soul.
 function item:on_obtaining(variant, savegame_variable)
-  local first_empty_bottle = self:get_game():get_first_empty_bottle()
-  if not self:get_game():has_bottle() or first_empty_bottle == nil then
-    -- The player has no bottle: do nothing.
+  local first_empty_bottle = game:get_first_empty_bottle()
+  if not game:has_bottle() or first_empty_bottle == nil then
+    -- The player has no bottle.
+    game:start_dialog("found_fairy.no_empty_bottle")
+    sol.audio.play_sound("wrong")
   else
     -- The player has a bottle: start the dialog.
-    self:get_game():start_dialog("found_soul", function(answer)
+    game:start_dialog("found_soul", function(answer)
       if answer == "skipped" or answer == 2 then
-	  -- Let go.
+        -- Let go.
       else
-	-- Keep the spirit in a bottle.
-	if first_empty_bottle == nil then
-	  -- No empty bottle.
-	  self:get_game():start_dialog("found_fairy.no_empty_bottle", function()
-		-- Let go.
-	  end)
-	  sol.audio.play_sound("wrong")
-	else
-	  -- Okay, empty bottle.
-	  first_empty_bottle:set_variant(8)
-	  sol.audio.play_sound("danger")
-	end
+        -- Keep the spirit in a bottle.
+        first_empty_bottle:set_variant(8)
+        sol.audio.play_sound("danger")
       end
     end)
   end

--- a/data/maps/169.dat
+++ b/data/maps/169.dat
@@ -2289,8 +2289,8 @@ tile{
 
 wall{
   layer = 0,
-  x = 256,
-  y = 432,
+  x = 248,
+  y = 440,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2298,8 +2298,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 64,
-  y = 432,
+  x = 72,
+  y = 440,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2307,8 +2307,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 656,
-  y = 432,
+  x = 648,
+  y = 440,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2316,8 +2316,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 464,
-  y = 432,
+  x = 472,
+  y = 440,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2325,8 +2325,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 464,
-  y = 64,
+  x = 472,
+  y = 72,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2334,8 +2334,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 656,
-  y = 64,
+  x = 648,
+  y = 72,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2343,8 +2343,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 256,
-  y = 64,
+  x = 248,
+  y = 72,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2352,8 +2352,8 @@ wall{
 
 wall{
   layer = 0,
-  x = 64,
-  y = 64,
+  x = 72,
+  y = 72,
   width = 32,
   height = 32,
   stops_enemies = true,
@@ -2563,8 +2563,8 @@ destructible{
 destination{
   name = "room2_dest",
   layer = 0,
-  x = 672,
-  y = 85,
+  x = 664,
+  y = 93,
   direction = 3,
   sprite = "entities/destination",
 }
@@ -2572,8 +2572,8 @@ destination{
 destination{
   name = "room4_dest",
   layer = 0,
-  x = 672,
-  y = 453,
+  x = 664,
+  y = 461,
   direction = 3,
   sprite = "entities/destination",
 }
@@ -2581,8 +2581,8 @@ destination{
 destination{
   name = "room1_dest",
   layer = 0,
-  x = 272,
-  y = 85,
+  x = 264,
+  y = 93,
   direction = 3,
   sprite = "entities/destination",
 }
@@ -2590,8 +2590,8 @@ destination{
 destination{
   name = "room3_dest",
   layer = 0,
-  x = 272,
-  y = 453,
+  x = 264,
+  y = 461,
   direction = 3,
   sprite = "entities/destination",
 }
@@ -2599,8 +2599,8 @@ destination{
 teletransporter{
   name = "room1_tran",
   layer = 0,
-  x = 72,
-  y = 72,
+  x = 80,
+  y = 80,
   width = 16,
   height = 16,
   destination_map = "169",
@@ -2612,8 +2612,8 @@ teletransporter{
 teletransporter{
   name = "room2_tran",
   layer = 0,
-  x = 472,
-  y = 72,
+  x = 480,
+  y = 80,
   width = 16,
   height = 16,
   destination_map = "169",
@@ -2625,8 +2625,8 @@ teletransporter{
 teletransporter{
   name = "room3_tran",
   layer = 0,
-  x = 72,
-  y = 440,
+  x = 80,
+  y = 448,
   width = 16,
   height = 16,
   destination_map = "169",
@@ -2638,8 +2638,8 @@ teletransporter{
 teletransporter{
   name = "room4_tran",
   layer = 0,
-  x = 472,
-  y = 440,
+  x = 480,
+  y = 448,
   width = 16,
   height = 16,
   destination_map = "169",

--- a/data/maps/169.lua
+++ b/data/maps/169.lua
@@ -521,7 +521,7 @@ function room4_dest:on_activated()
 
       -- go to treasure room finally!
       game:set_value("i1609", 50) 
-      room4_tran:set_destination("treasure_dest")
+      room4_tran:set_destination_name("treasure_dest")
     end
 end
 
@@ -542,7 +542,13 @@ function treasure_dest:on_activated()
     map:create_chest({layer=0,x=1208,y=501,sprite="entities/chest_big",treasure_name="tunic", treasure_variant=3})
   elseif game:get_item("tunic"):get_variant() == 3 then
     map:create_chest({layer=0,x=1208,y=501,sprite="entities/chest_big",treasure_name="tunic", treasure_variant=4})
+  else
+    -- No more tunics available, chest is empty.
+    chest = map:create_chest({layer=0,x=1208,y=501,sprite="entities/chest_big"})
+    chest:set_open(true)
   end
+  -- Reset the count of perils so we can play the cave again.
+  game:set_value("i1609", 0)
 end
 
 function npc_moblin:on_interaction()

--- a/data/maps/170.lua
+++ b/data/maps/170.lua
@@ -70,7 +70,7 @@ function map:on_update()
 end
 
 function sensor_tileset:on_activated()
-  if game:get_value("i1613") == 1 then
+  --[[if game:get_value("i1613") == 1 then
     map:set_tileset("4")
   elseif game:get_value("i1613") == 2 then
     map:set_tileset("5")
@@ -86,7 +86,7 @@ function sensor_tileset:on_activated()
     map:set_tileset("10")
   elseif game:get_value("i1613") == 8 then
     map:set_tileset("11")
-  end
+  end--]]
 end
 
 function sensor_room:on_activated()

--- a/data/maps/174.lua
+++ b/data/maps/174.lua
@@ -42,7 +42,10 @@ function sensor_fairy_speak:on_activated()
   elseif game:get_value("i1608") == 5 then
     game:start_dialog("great_fairy.5.north", function()
       game:set_value("i1608", 6)
-      hero:start_treasure("sword", 3)
+      -- Upgrade the sword by one step.
+      -- To get the light sword we need the blacksmith's quest
+      -- and the fairy's quest but the order is not important.
+      hero:start_treasure("sword", game:get_value("i1821") == 1 and 2 or 3)
     end)
   elseif game:get_value("i1608") == 6 then
     game:start_dialog("great_fairy.6")

--- a/data/maps/3.lua
+++ b/data/maps/3.lua
@@ -166,8 +166,23 @@ function shop_poe_soul:on_interaction()
     game:start_dialog("_shop.question_ore", 80, function(answer)
       if answer == 1 then
         if game:get_value("i1836") >= 80 then
-          hero:start_treasure("poe_soul")
-          game:set_value("i1836",game:get_value("i1836")-80)
+          -- We need an empty bottle, otherwise we have to cancel the transaction.
+          -- Note that we also check for an empty bottle in item:on_obtaining() .
+          -- This is intentional since there are multiple ways to obtain a poe soul
+          -- but when on_obtaining() runs the money is already spent so we must not
+          -- call hero:start_treasure() at all.
+          local first_empty_bottle = game:get_first_empty_bottle()
+          if not game:has_bottle() or first_empty_bottle == nil then
+            -- The player has no bottle.
+	          self:get_game():start_dialog("found_fairy.no_empty_bottle")
+            sol.audio.play_sound("wrong")
+          else
+            -- ATTENTION: The treasure dialog "_treasure.poe_soul.1"
+            -- must not be provided or it would try to create a dialog
+            -- on top of the shop dialog and thus cause a fatal error. 
+            hero:start_treasure("poe_soul")
+            game:set_value("i1836",game:get_value("i1836")-80)
+          end
         else
           game:start_dialog("_shop.not_enough_money")
         end

--- a/data/maps/4.dat
+++ b/data/maps/4.dat
@@ -7337,7 +7337,7 @@ shop_treasure{
   x = 160,
   y = 112,
   treasure_name = "bomb_bag",
-  treasure_savegame_variable = "i1806",
+  treasure_savegame_variable = "b2017",
   price = 400,
   dialog = "shop.bomb_bag_1",
 }
@@ -7415,7 +7415,7 @@ shop_treasure{
   x = 88,
   y = 456,
   treasure_name = "bomb_bag",
-  treasure_savegame_variable = "i1806",
+  treasure_savegame_variable = "b2017",
   price = 300,
   dialog = "shop.bomb_bag_1",
 }

--- a/data/maps/4.lua
+++ b/data/maps/4.lua
@@ -82,7 +82,7 @@ function map:on_started(destination)
 	treasure_variant = 3
     })
   end
-  if game:get_value("i1806") then --bomb_bag
+  if game:get_value("b2017") then --bomb_bag
     self:create_shop_treasure({
 	name = "shop_item_5",
 	layer = 0,

--- a/data/maps/9.lua
+++ b/data/maps/9.lua
@@ -134,7 +134,10 @@ end)
 function sensor_leaving:on_activated()
   if game:get_ability("sword") == 0 then
     game:start_dialog("rudy.5.sword_leaving", function()
-      hero:start_treasure("sword", 2)
+      -- Upgrade the sword by one step.
+      -- To get the light sword we need the blacksmith's quest
+      -- and the fairy's quest but the order is not important.
+      hero:start_treasure("sword", game:get_value("i1821") == 1 and 2 or 3)
       game:set_value("i1841", 5) -- Remove Master Ore.
       game:set_value("i1902", 6)
       game:set_value("i1652", 5)

--- a/data/scripts/game_manager.lua
+++ b/data/scripts/game_manager.lua
@@ -25,6 +25,17 @@ function game:on_started()
   self.hud = hud_manager:create(game)
   camera = camera_manager:create(game)
   tone = tone_manager:create(game)
+
+  -- Load the sprite of the tunic last equipped.
+  -- Note that we don't access the tunic entity itself:
+  -- This game has its own tunic ability management
+  -- based on the variable "tunic_equipped", the ability
+  -- built into the engine doesn't support choosing
+  -- between different tunics and is thus just used
+  -- to provide the different sprites.
+  local equipped = game:get_value("tunic_equipped")
+  local hero = game:get_hero()
+  hero:set_tunic_sprite_id("hero/tunic" .. equipped)
   
   -- Measure the time played.
   if game:get_value("time_played") == nil then game:set_value("time_played", 0) end


### PR DESCRIPTION
First I want to says thanks for this great game, it's currently my favorite game on the Solarus engine.
When I defeated the final boss I had completed a little more than 50%.
Resolving the missing quests and items revealed some bugs. Being a programmer myself
I decided to take the plunge, dive into Lua and hunt the bugs down. Here are the results.

- Shopping in Ordon Village didn't work as expected.
  There was an attempt to access a deleted item (nil value) so the script failed
  before items such as the Ordon Shield were replaced.
  I refactored the code and introduced the function replace_shop_treasure()
  to prevent this. There were also some issues with the available potions.

- The flower quest had a bug: It checked for 13 plants instead of 16 .

- It was possible to get a sword downgrade by first getting the Light Sword from the fairy
  and then going to the blacksmith. I changed that so now you have to visit both,
  the blacksmith and the fairy in any order:
  If you visit the fairy before the blacksmith you will get the Forged Sword
  from the fairy and the Light Sword from the blacksmith.

- The Cave of Ordeals didn't work for multiple reasons:
1. Often an enemy kicked you into the wall immediately after teleportation.
   I moved the teleporters away from the wall so this shouldn't happen anymore.
2. The hero wasn't teleported to the treasure room because the method set_destination()
   doesn't exist, it's actually set_destination_name() .
3. You got a tunic upgrade once. If you still had the green or red tunic at this
   point you were never able to get the purple tunic at all.
   Now the count of perils is reset after being teleported to the treasure room
   so you can play the cave again until you get the purple tunic.
   This might not be as intended, perhaps the purple tunic should be the only avaiable treasure here?

- The boss run was impossible because you couldn't defeat the Vire Sorceror.
  After you hit him the first time he was teleported to coordinates valid in the mausoleum
  (a local keyword in the if-block was the culprit here) and thus out of the room.
  Stalfos had a similar problem that made him stuck in the wall so you were unable to hit him.
  Changing the tileset on boss change is cool but also confusing (and sometimes doesn't work),
  I disabled it in the code for now.

- Buying or getting a poe soul from the chest on subrosia without having an empty bottle
  didn't give you any hint about the problem. In fact I didn't realize there's a soul-bottle dependency
  before looking at the code. Now the message about a missing bottle is shown.

- If you bought the bomb bag in Kakariko it tried to save its state in the wrong variable
  (i1806 instead of b2017). That failed and thus the bomb bag stayed available in the shop,
  makeing it possible to get a downgrade.

- A jumping tektite caused a C++ exception on jumping because properties.jumping_speed was nil
  (the table entry has the name properties.jump_speed). This didn't cause a crash, at least not on Linux
  but made the enemy invincible. If you had to kill all tektites in the room your only option was
  leaving the dungeon and being fast enough next time.

- Things I couldn't fix:
  The Book of Zora and the Book of Zola aren't available at all
  (I checked the code and found no corresponding locations).

That said, I love this game and I hope I did something to improve it :-)