### PR TITLE
Respect solarus install variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ project(ZBOM)
 
 set(quest_name "zbom")
 
+set(SOLARUS_INSTALL_DATAROOTDIR "share" CACHE PATH "dataroot dir")
+set(SOLARUS_INSTALL_DATADIR "${SOLARUS_INSTALL_DATAROOTDIR}/solarus" CACHE PATH "data dir")
+set(SOLARUS_INSTALL_BINDIR "bin" CACHE PATH "bin dir")
+
+if (IS_ABSOLUTE ${SOLARUS_INSTALL_DATADIR})
+  set(SOLARUS_INSTALL_ABSOLUTE_DATADIR ${SOLARUS_INSTALL_DATADIR})
+else()
+  set(SOLARUS_INSTALL_ABSOLUTE_DATADIR ${CMAKE_INSTALL_PREFIX}/${SOLARUS_INSTALL_DATADIR})
+endif()
+
 # data files list
 file(GLOB_RECURSE data_files
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/data
@@ -46,8 +56,8 @@ add_custom_target(${quest_name}_data
 # create a script that executes the engine with this quest
 add_custom_command(
   OUTPUT ${quest_name}
-  COMMAND echo '\#!/bin/bash' > ${quest_name}
-  COMMAND echo 'solarus ${CMAKE_INSTALL_PREFIX}/share/solarus/${quest_name} $*' >> ${quest_name}
+  COMMAND echo '\#!/bin/sh' > ${quest_name}
+  COMMAND echo 'solarus-run ${SOLARUS_INSTALL_ABSOLUTE_DATADIR}/${quest_name} $$*' >> ${quest_name}
 )
 add_custom_target(${quest_name}_command
   ALL
@@ -56,10 +66,10 @@ add_custom_target(${quest_name}_command
 
 # install the data archive
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/data.solarus
-  DESTINATION share/solarus/${quest_name}
+  DESTINATION ${SOLARUS_INSTALL_DATADIR}/${quest_name}
 )
 
 # install the script
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${quest_name}
-  DESTINATION bin
+  DESTINATION ${SOLARUS_INSTALL_BINDIR}
 )


### PR DESCRIPTION
This adds `SOLARUS_INSTALL_DATAROOTDIR`, `SOLARUS_INSTALL_DATADIR` and `SOLARUS_INSTALL_BINDIR` from the other Solarus games.

This is useful when install the game with cmake so that the install paths are correct and not hard coded.

I also included some other minor changes from other Solarus games.

* The launcher script now uses `#!/bin/sh` instead of `#!/bin/bash`, this script is so trivial it doesn't need to force bash.
* It now uses `solarus-run` instead of `solarus` to launch to the game like with other solarus games.